### PR TITLE
FEAT: generate an active record model for the User

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,7 @@ gem 'puma', '~> 5.0'
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem 'bcrypt', '~> 3.1.7'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 
 group :test do
   gem 'database_cleaner-active_record'
+  gem 'shoulda-matchers', '~> 5.0'
   gem 'simplecov', require: false
   gem 'simplecov-json', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    bcrypt (3.1.20)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     brakeman (5.4.1)
@@ -233,6 +234,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   database_cleaner-active_record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,8 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -248,6 +250,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
+  shoulda-matchers (~> 5.0)
   simplecov
   simplecov-json
   tzinfo-data

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_secure_password
+
   validates :full_name, :username, presence: true
   validates :email, presence: true, email: true, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,6 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
+  validates :full_name, :username, presence: true
+  validates :email, presence: true, email: true, uniqueness: true
 end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class EmailValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if URI::MailTo::EMAIL_REGEXP.match?(value)
+
+    record.errors.add attribute, (options[:message] || 'is not an email')
+  end
+end

--- a/db/migrate/20231221033610_create_users.rb
+++ b/db/migrate/20231221033610_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :users do |t|
@@ -7,6 +9,8 @@ class CreateUsers < ActiveRecord::Migration[7.0]
       t.string :password_digest
 
       t.timestamps
+
+      t.index :email, unique: true
     end
   end
 end

--- a/db/migrate/20231221033610_create_users.rb
+++ b/db/migrate/20231221033610_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :full_name
+      t.string :username
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_21_033610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "full_name"
+    t.string "username"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
-    email { "MyString" }
-    full_name { "MyString" }
-    username { "MyString" }
-    password_digest { "MyString" }
+    email { Faker::Internet.unique.email }
+    full_name { Faker::Name.name }
+    username { Faker::Internet.username }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    email { "MyString" }
+    full_name { "MyString" }
+    username { "MyString" }
+    password_digest { "MyString" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     full_name { Faker::Name.name }
     username { Faker::Internet.username }
+    password { Faker::Internet.password }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
+RSpec.describe User do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:full_name) }
+    it { is_expected.to validate_presence_of(:username) }
+    it { is_expected.to validate_uniqueness_of(:email) }
+
+    context 'when user email is invalid' do
+      subject(:user) { build(:user, email: 'invalid_email.com') }
+
+      it do
+        user.valid?
+
+        expect(user.errors.full_messages).to eq(['Email is not an email'])
+      end
+    end
+  end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
In this pull request, we're diving into the user registration feature. It creates the Active Record model for our User. The User model will be the backbone for managing user-related data in our application.

Follow these steps to generate the model user and add its validations:

### Generate the model by rails generator command:
`bundle exec rails generate model User email full_name username password_digest`

### Use Faker gem to generate realistic data
Update the user factory definition file (spec/factories/users.rb) to this:

```ruby
# frozen_string_literal: true

FactoryBot.define do
  factory :user do
    email { Faker::Internet.unique.email }
    full_name { Faker::Name.name }
    username { Faker::Internet.username }
  end
end

```

_These changes will ensure that each time you create a user using this user factory, the email, full name and username will be populated with realistic and unique values generated by Faker_

### Validate user's attributes
Change the user model file (app/models/user.rb) to this:

```ruby
# frozen_string_literal: true

class User < ApplicationRecord
  validates :full_name, :username, presence: true
  validates :email, presence: true, uniqueness: true
end
```

### Create a custom validator for email
- Create a file at `app/validators/email_validator.rb`:
```ruby
# frozen_string_literal: true

class EmailValidator < ActiveModel::EachValidator
  def validate_each(record, attribute, value)
    return if URI::MailTo::EMAIL_REGEXP.match?(value)

    record.errors.add attribute, (options[:message] || 'is not an email')
  end
end
```

_It validates whether a given value represents a valid email address using the URI::MailTo::EMAIL_REGEXP regular expression. If the value matches the email format, no error is added to the record.errors collection; otherwise, an error message indicating that the value "is not an email" is added._

- Use this custom validator at user:
```ruby
# ...
validates :email, presence: true, email: true, uniqueness: true
# ...
```
_`email: true`  this part triggers our custom validator (EmailValidator) for the :email attribute._

### Add index unique for email
Adding a unique index for columns that require uniqueness in a database is highly recommended for several reasons:
- enforcing uniqueness at the database level and data integrity
- improved query performance (when there is a uniqueness validation, active record constructs a query to check whether a record with the same value for the unique attribute already exists in the database, without, index it would take a considerable time in a large dataset)
- error prevention (attempts to insert duplicate values will result in an error at the database level)
- better handling of concurrent operations (prevents race conditions by ensuring that no two transactions can commit conflicting data).

To do that, let's open the migration file generated (db/migrate/..._create_users.rb) and add the line code `t.index :email, unique: true` below the `t.timestamps` line. It should be like this:

```ruby
# frozen_string_literal: true

class CreateUsers < ActiveRecord::Migration[7.0]
  def change
    create_table :users do |t|
      t.string :email
      t.string :full_name
      t.string :username
      t.string :password_digest

      t.timestamps

      t.index :email, unique: true
    end
  end
end
```
### Run the database migrate command
```shell
bundle exec rails db:migrate
```

### Using the bcrypt gem to store the user's password safely.
- Open the Gemfile and add the bcrypt gem:
```ruby
gem 'bcrypt', '~> 3.1.7'
```

- In our model file (user.rb), use `has_secure_password`:
```ruby
class User < ApplicationRecord
  has_secure_password

  # ...
end
```
_This line automatically adds functionality for securely hashing and authenticating passwords using Bcrypt_

- Add the password field at users factory:
```ruby
# ...
password { Faker::Internet.password }
# ...
```

_By default bcrypt uses the `password_digest` field (it was already add in our model) to store the password and adds password getter and setter method._

### Test the validations with should matchers gem

- Add gem in Gemfile: `gem 'shoulda-matchers', '~> 5.0'`
- Install gem with `bundle install` command
- Create a file at `spec/support/shoulda_matchers.rb` to configure the shoulda_matchers:

```ruby
# frozen_string_literal: true

Shoulda::Matchers.configure do |config|
  config.integrate do |with|
    with.test_framework :rspec
    with.library :rails
  end
end

```
- Create tests for the user model:

```ruby
# frozen_string_literal: true

require 'rails_helper'

RSpec.describe User do
  describe 'validations' do
      it { is_expected.to validate_presence_of(:email) }
      it { is_expected.to validate_presence_of(:full_name) }
      it { is_expected.to validate_presence_of(:username) }
      it { is_expected.to validate_uniqueness_of(:email) }
  
      context 'when user email is invalid' do
        subject(:user) { build(:user, email: 'invalid_email.com') }
  
        it do
          user.valid?
  
          expect(user.errors.full_messages).to eq(['Email is not an email'])
        end
      end
    end
end
```