### PR TITLE
FEAT: create endpoint to sign in

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Things you may want to cover:
 * ...
 
 ## API Documentation (cURL examples)
-### User
 
-#### Sign up
+### Sign up
 ```shell
 curl --location --request POST 'http://localhost:3000/api/v1/sign_up' \
 --header 'Content-Type: application/json' \
@@ -38,5 +37,15 @@ curl --location --request POST 'http://localhost:3000/api/v1/sign_up' \
         "password": "dd",
         "password_confirmation": "dd"
     }
+}'
+```
+
+### Sign in
+```shell
+curl --location --request POST 'http://localhost:3000/api/v1/sign_in' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "email": "r5@gmail.com",
+    "password": "dd"
 }'
 ```

--- a/app/controllers/api/v1/serializers/session_serializer.rb
+++ b/app/controllers/api/v1/serializers/session_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Serializers
+      class SessionSerializer < ActiveModel::Serializer
+        attributes :user_id, :token, :refresh_token, :expires_in, :refresh_expires_in, :created_at
+        attribute :email
+
+        def email = object.user.email
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sign_in_controller.rb
+++ b/app/controllers/api/v1/sign_in_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SignInController < ApplicationController
+      def create
+        case Auth::SignInCommand.call(params: auth_params)
+        in Result::Success(session:)
+          render json: session, status: :ok, serializer: Serializers::SessionSerializer
+        in Result::Failure
+          render json: { errors: ['invalid credentials'] }, status: :unauthorized
+        end
+      end
+
+      private
+
+      def auth_params
+        params.permit(:email, :password).to_h
+      end
+    end
+  end
+end

--- a/app/models/auth/sign_in_command.rb
+++ b/app/models/auth/sign_in_command.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Auth
+  class SignInCommand < ApplicationCommand
+    def initialize(params:)
+      self.params = params
+    end
+
+    def call
+      user = User.find_by!(email: params[:email])
+
+      if user.authenticate(params[:password])
+        session = create_session(user)
+        Result::Success(:ok, session:, user:)
+      else
+        Result::Failure(:unauthorized, errors: ['invalid credentials'])
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      Result::Failure(:not_found, errors: [e.message])
+    end
+
+    private
+
+    attr_accessor :params
+
+    def create_session(user)
+      user.sessions.create!(
+        token: SecureRandom.alphanumeric(32),
+        refresh_token: SecureRandom.alphanumeric(32),
+        expires_in: 2.hours.from_now,
+        refresh_expires_in: 1.week.from_now
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :sign_up, only: :create
+      resources :sign_in, only: :create
     end
   end
 end

--- a/spec/models/auth/sign_in_command_spec.rb
+++ b/spec/models/auth/sign_in_command_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Auth::SignInCommand do
+  describe '#call' do
+    subject(:sign_in) { described_class.call(params:) }
+
+    let!(:user_params) { create(:user) }
+
+    before { freeze_time }
+
+    context 'with valid credentials' do
+      let(:params) do
+        {
+          email: user_params.email,
+          password: user_params.password
+        }
+      end
+
+      it 'creates a session' do
+        expect { sign_in }.to change(Session, :count).by(1)
+      end
+
+      it 'returns a success result' do
+        response = sign_in
+
+        expect(response).to be_a(Result::Success)
+      end
+
+      it 'returns a session for the right user' do
+        sign_in => {session:}
+
+        expect(session).to have_attributes(
+          user_id: user_params.id,
+          token: be_a(String),
+          refresh_token: be_a(String),
+          expires_in: be_within(2.hours).of(2.hours.from_now),
+          refresh_expires_in: be_within(1.week).of(1.week.from_now),
+          refreshed_at: nil
+        )
+      end
+
+      it 'returns the user' do
+        sign_in => {user:}
+
+        expect(user).to eq(user_params)
+      end
+    end
+
+    context 'with invalid email' do
+      let(:params) do
+        {
+          email: 'invalid@gmail.com',
+          password: user_params.password
+        }
+      end
+
+      it 'returns a failure result' do
+        response = sign_in
+
+        expect(response).to be_a(Result::Failure)
+      end
+
+      it 'returns an error message' do
+        sign_in => {errors:}
+
+        expect(errors).to match([/Couldn't find User/])
+      end
+
+      it 'does not create a session' do
+        expect { sign_in }.not_to change(Session, :count)
+      end
+
+      it 'return not_found failure type' do
+        sign_in => {type:}
+
+        expect(type).to eq(:not_found)
+      end
+    end
+
+    context 'with invalid password' do
+      let(:params) do
+        {
+          email: user_params.email,
+          password: 'invalid'
+        }
+      end
+
+      it 'returns a failure result' do
+        response = sign_in
+
+        expect(response).to be_a(Result::Failure)
+      end
+
+      it 'returns an error message' do
+        sign_in => {errors:}
+
+        expect(errors).to match(['invalid credentials'])
+      end
+
+      it 'does not create a session' do
+        expect { sign_in }.not_to change(Session, :count)
+      end
+
+      it 'return unauthorized failure type' do
+        sign_in => {type:}
+
+        expect(type).to eq(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/sign_in_spec.rb
+++ b/spec/requests/api/v1/sign_in_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::SignInController' do
+  describe 'POST /api/v1/sign_in' do
+    subject(:perform_request) { post '/api/v1/sign_in', params:, as: :json }
+
+    let!(:user) do
+      create(:user, email: 'rivelino@gmail.com', password: '9gU1qbBSoT', password_confirmation: '9gU1qbBSoT')
+    end
+
+    context 'with valid credentials' do
+      let(:params) do
+        {
+          email: 'rivelino@gmail.com',
+          password: '9gU1qbBSoT'
+        }
+      end
+
+      it 'returns a 200 status code' do
+        perform_request
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a session' do
+        perform_request
+
+        user.reload
+        session = user.sessions.last
+
+        expect(response.parsed_body).to eq(
+          'user_id' => user.id,
+          'token' => session.token,
+          'refresh_token' => session.refresh_token,
+          'expires_in' => session.expires_in.iso8601(3),
+          'refresh_expires_in' => session.refresh_expires_in.iso8601(3),
+          'created_at' => session.created_at.iso8601(3),
+          'email' => user.email
+        )
+      end
+    end
+
+    context 'with invalid email' do
+      let(:params) do
+        {
+          email: 'r@gmail.com',
+          password: '9gU1qbBSoT'
+        }
+      end
+
+      it 'returns a 401 status code' do
+        perform_request
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error message' do
+        perform_request
+
+        expect(response.parsed_body).to eq('errors' => ['invalid credentials'])
+      end
+    end
+
+    context 'with invalid password' do
+      let(:params) do
+        {
+          email: 'rivelino@gmail.com',
+          password: '9gU1qbBSoT------'
+        }
+      end
+
+      it 'returns a 401 status code' do
+        perform_request
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error message' do
+        perform_request
+
+        expect(response.parsed_body).to eq('errors' => ['invalid credentials'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
What was made:
- create an endpoint/controller to sign in
- create a command to sign in
- delete the concerns folder in the models
- document the endpoint in the readme