### PR TITLE
FEAT: create authenticate method to perform before controllers actions

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class BaseController < ApplicationController
+      include ActionController::HttpAuthentication::Token::ControllerMethods
+
+      before_action :authenticate!
+
+      private
+
+      attr_accessor :current_user, :current_session
+
+      def authenticate!
+        authenticate_with_http_token do |token, _options|
+          session, user = query_session(token)
+
+          self.current_user = user
+          self.current_session = session
+        end
+
+        return if current_session && current_user
+
+        render json: { errors: ['invalid session token'] }, status: :unauthorized
+      end
+
+      def query_session(token)
+        @query_session ||=
+          case Auth::CurrentSessionQuery.query(token:)
+          in Result::Success(session:, user:)
+            [session, user]
+          in Result::Failure
+            [nil, nil]
+          end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sign_in_controller.rb
+++ b/app/controllers/api/v1/sign_in_controller.rb
@@ -2,7 +2,9 @@
 
 module Api
   module V1
-    class SignInController < ApplicationController
+    class SignInController < BaseController
+      skip_before_action :authenticate!
+
       def create
         case Auth::SignInCommand.call(params: auth_params)
         in Result::Success(session:)

--- a/app/controllers/api/v1/sign_up_controller.rb
+++ b/app/controllers/api/v1/sign_up_controller.rb
@@ -2,7 +2,9 @@
 
 module Api
   module V1
-    class SignUpController < ApplicationController
+    class SignUpController < BaseController
+      skip_before_action :authenticate!
+
       def create
         case Users::SignUpCommand.call(params: user_params)
         in Result::Success(user:)

--- a/app/queries/application_query.rb
+++ b/app/queries/application_query.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationQuery
+  def self.query(**args) = new(**args).query
+
+  def query = raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+
+  private_class_method :new
+end

--- a/app/queries/auth/current_session_query.rb
+++ b/app/queries/auth/current_session_query.rb
@@ -1,0 +1,19 @@
+module Auth
+  class CurrentSessionQuery < ApplicationQuery
+    def initialize(token:)
+      self.token = token
+    end
+
+    def query
+      session = Session.find_by!(token:)
+
+      Result::Success(:ok, session:, user: session.user)
+    rescue ActiveRecord::RecordNotFound => e
+      Result::Failure(:not_found, errosr: [e.message])
+    end
+
+    private
+
+    attr_accessor :token
+  end
+end

--- a/app/queries/auth/current_session_query.rb
+++ b/app/queries/auth/current_session_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Auth
   class CurrentSessionQuery < ApplicationQuery
     def initialize(token:)


### PR DESCRIPTION
What was made:
- [create query object to retrieve the current session](https://github.com/rivelinojunior/e_social_mine_api/commit/afba72c71e785a71c41d31a411f592186ca1a9a7)
- [create base controller and authenticate method](https://github.com/rivelinojunior/e_social_mine_api/commit/3ebc203a095ff382ae8fcb7e55c04bf7373fc7ee)
- [skip authenticate method in sign in and sign up controllers](https://github.com/rivelinojunior/e_social_mine_api/commit/2e1b30a178e94e8a732ba78094da7c15cc42560e)