### PR TITLE
FIX: verify the session expiration

### DIFF
--- a/app/queries/auth/current_session_query.rb
+++ b/app/queries/auth/current_session_query.rb
@@ -9,13 +9,17 @@ module Auth
     def query
       session = Session.find_by!(token:)
 
-      Result::Success(:ok, session:, user: session.user)
+      return Result::Success(:ok, session:, user: session.user) unless expired?(session.expires_in)
+
+      Result::Failure(:expired, errors: ['session expired'])
     rescue ActiveRecord::RecordNotFound => e
-      Result::Failure(:not_found, errosr: [e.message])
+      Result::Failure(:not_found, errors: [e.message])
     end
 
     private
 
     attr_accessor :token
+
+    def expired?(expires_in) = Time.current > expires_in
   end
 end

--- a/app/queries/auth/current_session_query.rb
+++ b/app/queries/auth/current_session_query.rb
@@ -9,9 +9,9 @@ module Auth
     def query
       session = Session.find_by!(token:)
 
-      return Result::Success(:ok, session:, user: session.user) unless expired?(session.expires_in)
+      return Result::Failure(:expired, errors: ['session expired']) if expired?(session.expires_in)
 
-      Result::Failure(:expired, errors: ['session expired'])
+      Result::Success(:ok, session:, user: session.user)
     rescue ActiveRecord::RecordNotFound => e
       Result::Failure(:not_found, errors: [e.message])
     end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     expires_in { 1.hour.from_now }
     refresh_expires_in { 1.week.from_now }
     refreshed_at { nil }
+
+    trait :expired do
+      expires_in { 1.hour.ago }
+    end
   end
 end

--- a/spec/queries/auth/current_session_query_spec.rb
+++ b/spec/queries/auth/current_session_query_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Auth::CurrentSessionQuery do
+  describe '.query' do
+    subject(:query) { described_class.query(token:) }
+
+    let(:token) { current_session.token }
+    let(:current_session) { create(:session) }
+
+    context 'when session is valid' do
+      it 'returns a success result' do
+        expect(query).to be_a(Result::Success)
+      end
+
+      it 'returns the session and user' do
+        result = query
+
+        expect(result.value).to eq(
+          session: current_session,
+          user: current_session.user
+        )
+      end
+    end
+
+    context 'when session is expired' do
+      let(:current_session) { create(:session, :expired) }
+
+      it 'returns a failure result' do
+        expect(query).to be_a(Result::Failure)
+      end
+
+      it 'returns an expired failure type' do
+        query => {type:}
+
+        expect(type).to eq(:expired)
+      end
+
+      it 'returns an error message' do
+        query => {errors:}
+
+        expect(errors).to eq(['session expired'])
+      end
+    end
+
+    context 'when session is not found' do
+      let(:token) { 'invalid_token' }
+
+      it 'returns a failure result' do
+        expect(query).to be_a(Result::Failure)
+      end
+
+      it 'returns an not_found failure type' do
+        query => {type:}
+
+        expect(type).to eq(:not_found)
+      end
+
+      it 'returns an error message' do
+        query => {errors:}
+
+        expect(errors).to match([/Couldn't find Session/])
+      end
+    end
+  end
+end

--- a/spec/queries/auth/current_session_query_spec.rb
+++ b/spec/queries/auth/current_session_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Auth::CurrentSessionQuery do


### PR DESCRIPTION
What was fixed:

- Verifying the experies_in property in the current session query
