### PR TITLE
FEAT: add column hashtags to post model

### DIFF
--- a/app/controllers/api/v1/serializers/post_serializer.rb
+++ b/app/controllers/api/v1/serializers/post_serializer.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module Serializers
       class PostSerializer < ActiveModel::Serializer
-        attributes :id, :content, :user_id, :created_at
+        attributes :id, :content, :user_id, :hashtags, :created_at
       end
     end
   end

--- a/db/migrate/20240625235339_add_column_hashtags_to_posts.rb
+++ b/db/migrate/20240625235339_add_column_hashtags_to_posts.rb
@@ -1,0 +1,5 @@
+class AddColumnHashtagsToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :hashtags, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_25_205821) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_25_235339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_25_205821) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "hashtags"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
   factory :post do
     user
     content { Faker::Lorem.paragraph }
+    hashtags { nil }
+
+    trait :with_hash_tags do
+      hashtags { Faker::Lorem.words(number: 5) }
+    end
   end
 end

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe 'Posts API V1' do
             'id' => post.id,
             'content' => 'Hello, world!',
             'user_id' => current_session.user_id,
-            'created_at' => post.created_at.iso8601(3)
+            'created_at' => post.created_at.iso8601(3),
+            'hashtags' => nil
           )
         end
       end


### PR DESCRIPTION
What was made:
- Add column hashtags to post model
- Create a trait in the posts factory to fill the hashtags field (:with_hashtags)