### PR TITLE
FEAT: create reactions model

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Reaction < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  enum kind: { like: 'like', celebrate: 'celebrate', support: 'support', love: 'love', insightful: 'insightful', funny: 'funny' }
+
+  validates :kind, presence: true
+end

--- a/db/migrate/20240701224342_create_reactions.rb
+++ b/db/migrate/20240701224342_create_reactions.rb
@@ -1,0 +1,11 @@
+class CreateReactions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.string :kind
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_28_022824) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_01_224342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_28_022824) do
     t.datetime "updated_at", null: false
     t.jsonb "hashtags"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "reactions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.string "kind"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_reactions_on_post_id"
+    t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
   create_table "relationships", force: :cascade do |t|
@@ -58,6 +68,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_28_022824) do
   end
 
   add_foreign_key "posts", "users"
+  add_foreign_key "reactions", "posts"
+  add_foreign_key "reactions", "users"
   add_foreign_key "relationships", "users", column: "followee_id"
   add_foreign_key "relationships", "users", column: "follower_id"
   add_foreign_key "sessions", "users"

--- a/spec/factories/reactions.rb
+++ b/spec/factories/reactions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :reaction do
+    user
+    post
+    kind { Reaction.kinds.keys.sample }
+  end
+end

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reaction do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:kind) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:post) }
+  end
+
+  describe '.kinds' do
+    subject(:kinds) { described_class.kinds }
+
+    it do
+      expect(kinds).to eq(
+        'like' => 'like',
+        'celebrate' => 'celebrate',
+        'support' => 'support',
+        'love' => 'love',
+        'insightful' => 'insightful',
+        'funny' => 'funny'
+      )
+    end
+  end
+end


### PR DESCRIPTION
What was made:

- generate migration to create reactions table
- generate reaction model
- add validation and enum for the kind of reactions