### PR TITLE
FEAT: generate comment model

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :post
+  belongs_to :user
+
+  validates :message, presence: true
+end

--- a/db/migrate/20240710005406_create_comments.rb
+++ b/db/migrate/20240710005406_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_01_224342) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_10_005406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "user_id", null: false
+    t.string "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -67,6 +77,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_01_224342) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "reactions", "posts"
   add_foreign_key "reactions", "users"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment do
+    post
+    user
+    message { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Comment do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:message) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:post) }
+    it { is_expected.to belong_to(:user) }
+  end
+end


### PR DESCRIPTION
What was made:
- generate comment model performing the command: ` bundle exec rails g model Comments post:references user:references message`
- add presence validation for the comment's message